### PR TITLE
Set minimum priority to 1

### DIFF
--- a/Main.cpp
+++ b/Main.cpp
@@ -102,13 +102,13 @@ Export int InitProc()
     SetupAIDefense();
 
     // Set reinforce info
-    saveData.aiBuildGrp.RecordVehReinforceGroup(saveData.aiDefGrp[0], 0);
+    saveData.aiBuildGrp.RecordVehReinforceGroup(saveData.aiDefGrp[0], 1);
     saveData.aiBuildGrp.RecordVehReinforceGroup(saveData.aiDefGrp[1], 5000); // Very high priority; it's the lab
     saveData.aiBuildGrp.RecordVehReinforceGroup(saveData.aiDefGrp[2], 5000); // Also high; the CC
     saveData.aiBuildGrp.RecordVehReinforceGroup(saveData.aiDefGrp[3], 5000); // Factories
-    saveData.aiBuildGrp.RecordVehReinforceGroup(saveData.aiDefGrp[4], 0);
-    saveData.aiBuildGrp.RecordVehReinforceGroup(saveData.aiDefGrp[5], 0);
-    saveData.aiBuildGrp.RecordVehReinforceGroup(saveData.aiDefGrp[6], 0);
+    saveData.aiBuildGrp.RecordVehReinforceGroup(saveData.aiDefGrp[4], 1);
+    saveData.aiBuildGrp.RecordVehReinforceGroup(saveData.aiDefGrp[5], 1);
+    saveData.aiBuildGrp.RecordVehReinforceGroup(saveData.aiDefGrp[6], 1);
 
 	// Turn on vehicle lights
 	PlayerVehicleEnum vehEnum(0);


### PR DESCRIPTION
The random weighted selection algorithm the game uses needs a non-zero priority value to distinguish one target action from another. Using a minimum priority value of 1 may be required to prevent an infinite loop hang. This is a speculative guess.

Edit: Closes #3.
