### PR TITLE
Switch to winres for resource include header

### DIFF
--- a/PlymouthColdWar.rc
+++ b/PlymouthColdWar.rc
@@ -7,7 +7,7 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include "winres.h"
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS


### PR DESCRIPTION
I believe afxres is not available without enabling MFC and compiler complains about it.